### PR TITLE
Making QoS a presence container

### DIFF
--- a/yang/ietf-packet-discard-reporting-sx.yang
+++ b/yang/ietf-packet-discard-reporting-sx.yang
@@ -222,17 +222,22 @@ module ietf-packet-discard-reporting-sx {
   grouping qos {
     description
       "Quality of Service (QoS) traffic counters.";
-    list class {
-      key "id";
-      min-elements 1;
+    container qos {
+      presence "QoS statistics are available.";
       description
-        "QoS class traffic counters.";
-      leaf id {
-        type string;
+        "QoS traffic counters.";
+      list class {
+        key "id";
+        min-elements 1;
         description
-          "QoS class identifier.";
+          "QoS class traffic counters.";
+        leaf id {
+          type string;
+          description
+            "QoS class identifier.";
+        }
+        uses basic-packets-bytes;
       }
-      uses basic-packets-bytes;
     }
   }
 
@@ -249,11 +254,7 @@ module ietf-packet-discard-reporting-sx {
         "Layer 3 traffic counters.";
       uses l3-traffic;
     }
-    container qos {
-      description
-        "QoS traffic counters.";
-      uses qos;
-    }
+    uses qos;
   }
 
   grouping errors-l2-rx {

--- a/yang/trees/ietf-packet-discard-reporting-sx.tree
+++ b/yang/trees/ietf-packet-discard-reporting-sx.tree
@@ -30,7 +30,7 @@ module: ietf-packet-discard-reporting-sx
     |  |  |     +-- multicast
     |  |  |        +-- packets?   yang:counter64
     |  |  |        +-- bytes?     yang:counter64
-    |  |  +-- qos
+    |  |  +-- qos!
     |  |     +-- class* [id]
     |  |        +-- id         string
     |  |        +-- packets?   yang:counter64
@@ -90,10 +90,11 @@ module: ietf-packet-discard-reporting-sx
     |     |     +-- rpf?          yang:counter64
     |     |     +-- ddos?         yang:counter64
     |     +-- no-buffer
-    |        +-- class* [id]
-    |           +-- id         string
-    |           +-- packets?   yang:counter64
-    |           +-- bytes?     yang:counter64
+    |        +-- qos!
+    |           +-- class* [id]
+    |              +-- id         string
+    |              +-- packets?   yang:counter64
+    |              +-- bytes?     yang:counter64
     +-- flow* [direction] {flow-reporting}?
     |  +-- direction    identityref
     |  +-- traffic
@@ -111,7 +112,7 @@ module: ietf-packet-discard-reporting-sx
     |  |  |     +-- multicast
     |  |  |        +-- packets?   yang:counter64
     |  |  |        +-- bytes?     yang:counter64
-    |  |  +-- qos
+    |  |  +-- qos!
     |  |     +-- class* [id]
     |  |        +-- id         string
     |  |        +-- packets?   yang:counter64
@@ -170,10 +171,11 @@ module: ietf-packet-discard-reporting-sx
     |     |     +-- rpf?          yang:counter64
     |     |     +-- ddos?         yang:counter64
     |     +-- no-buffer
-    |        +-- class* [id]
-    |           +-- id         string
-    |           +-- packets?   yang:counter64
-    |           +-- bytes?     yang:counter64
+    |        +-- qos!
+    |           +-- class* [id]
+    |              +-- id         string
+    |              +-- packets?   yang:counter64
+    |              +-- bytes?     yang:counter64
     +-- device {device-stats}?
        +-- traffic
        |  +-- l2
@@ -190,7 +192,7 @@ module: ietf-packet-discard-reporting-sx
        |  |     +-- multicast
        |  |        +-- packets?   yang:counter64
        |  |        +-- bytes?     yang:counter64
-       |  +-- qos
+       |  +-- qos!
        |     +-- class* [id]
        |        +-- id         string
        |        +-- packets?   yang:counter64
@@ -249,7 +251,8 @@ module: ietf-packet-discard-reporting-sx
           |     +-- rpf?          yang:counter64
           |     +-- ddos?         yang:counter64
           +-- no-buffer
-             +-- class* [id]
-                +-- id         string
-                +-- packets?   yang:counter64
-                +-- bytes?     yang:counter64
+             +-- qos!
+                +-- class* [id]
+                   +-- id         string
+                   +-- packets?   yang:counter64
+                   +-- bytes?     yang:counter64

--- a/yang/trees/ietf-packet-discard-reporting.tree
+++ b/yang/trees/ietf-packet-discard-reporting.tree
@@ -28,7 +28,7 @@ module: ietf-packet-discard-reporting
   |  |  |     +--ro multicast
   |  |  |        +--ro packets?   yang:counter64
   |  |  |        +--ro bytes?     yang:counter64
-  |  |  +--ro qos
+  |  |  +--ro qos!
   |  |     +--ro class* [id]
   |  |        +--ro id         string
   |  |        +--ro packets?   yang:counter64
@@ -88,10 +88,11 @@ module: ietf-packet-discard-reporting
   |     |     +--ro rpf?          yang:counter64
   |     |     +--ro ddos?         yang:counter64
   |     +--ro no-buffer
-  |        +--ro class* [id]
-  |           +--ro id         string
-  |           +--ro packets?   yang:counter64
-  |           +--ro bytes?     yang:counter64
+  |        +--ro qos!
+  |           +--ro class* [id]
+  |              +--ro id         string
+  |              +--ro packets?   yang:counter64
+  |              +--ro bytes?     yang:counter64
   +--ro device! {device-stats}?
      +--ro traffic
      |  +--ro l2
@@ -108,7 +109,7 @@ module: ietf-packet-discard-reporting
      |  |     +--ro multicast
      |  |        +--ro packets?   yang:counter64
      |  |        +--ro bytes?     yang:counter64
-     |  +--ro qos
+     |  +--ro qos!
      |     +--ro class* [id]
      |        +--ro id         string
      |        +--ro packets?   yang:counter64
@@ -167,7 +168,8 @@ module: ietf-packet-discard-reporting
         |     +--ro rpf?          yang:counter64
         |     +--ro ddos?         yang:counter64
         +--ro no-buffer
-           +--ro class* [id]
-              +--ro id         string
-              +--ro packets?   yang:counter64
-              +--ro bytes?     yang:counter64
+           +--ro qos!
+              +--ro class* [id]
+                 +--ro id         string
+                 +--ro packets?   yang:counter64
+                 +--ro bytes?     yang:counter64


### PR DESCRIPTION
`min-elements 1` makes qos mandatory. Converting it into a presence container. Another option is to remove `min-elements `