### PR TITLE
Johnevansuk patch 11

### DIFF
--- a/yang/ietf-packet-discard-reporting-common.yang
+++ b/yang/ietf-packet-discard-reporting-common.yang
@@ -325,6 +325,16 @@ module ietf-packet-discard-reporting-common {
         description
           "The number of received packets discarded due
            to a checksum error.";
+        description
+          "Reports IPv4 packets discarded because validation of the
+           IPv4 header checksum failed.
+
+           This counter is applicable only to IPv4 packets. IPv6 does
+           not include an internet-layer header checksum, so IPv6
+           packets are not reported under this counter. solely due to
+           IPv6 header processing. Upper-layer checksum failures,
+           including TCP, UDP, or ICMPv6 checksum failures, are not
+           reported by this L3 header checksum counter.";
       }
       leaf mtu-exceeded {
         type yang:counter64;
@@ -357,11 +367,13 @@ module ietf-packet-discard-reporting-common {
     leaf invalid-sid {
       type yang:counter64;
       description
-        "The number of received packets discarded due to an
-         invalid Segment Routing over IPv6 (SRv6) segment 
-         identifier (SID).
-         For SR-MPLS, invalid SIDs have to be accounted
-         under invalid-label.";
+        "Reports SRv6 packets discarded because SRv6 Segment
+         Identifier (SID) processing failed. This includes packets
+         for which the active SID is invalid, unsupported, not
+         locally instantiated, not valid for the expected SRv6
+         endpoint behavior, or otherwise cannot be processed
+         according to the local SRv6 configuration and supported
+         endpoint behaviours.";
     }
     leaf invalid-label {
       type yang:counter64;

--- a/yang/ietf-packet-discard-reporting-common.yang
+++ b/yang/ietf-packet-discard-reporting-common.yang
@@ -365,12 +365,7 @@ module ietf-packet-discard-reporting-common {
       type yang:counter64;
       description
         "Reports SRv6 packets discarded because SRv6 Segment
-         Identifier (SID) processing failed. This includes packets
-         for which the active SID is invalid, unsupported, not
-         locally instantiated, not valid for the expected SRv6
-         endpoint behavior, or otherwise cannot be processed
-         according to the local SRv6 configuration and supported
-         endpoint behaviours.";
+         Identifier (SID) processing failed.";
     }
     leaf invalid-label {
       type yang:counter64;

--- a/yang/ietf-packet-discard-reporting-common.yang
+++ b/yang/ietf-packet-discard-reporting-common.yang
@@ -323,9 +323,6 @@ module ietf-packet-discard-reporting-common {
       leaf checksum-error {
         type yang:counter64;
         description
-          "The number of received packets discarded due
-           to a checksum error.";
-        description
           "Reports IPv4 packets discarded because validation of the
            IPv4 header checksum failed.
 


### PR DESCRIPTION
Address Carlos comments:
5. `checksum-error` (errors-l3-rx) does not note that IPv4 has a header checksum and IPv6 does not (RFC 791 vs. RFC 8200) -- applicability by address family could be stated.
6. `invalid-sid` lacks an informative reference to SRv6 architecture (RFC 8402 / RFC 8986).

Changes
- Clarify that checksum-error reports IPv4 header checksum failures only.
- State that checksum-error is not applicable to IPv6 internet-layer header processing.
- Clarify that upper-layer checksum failures are outside this L3 checksum-error counter.
- Clarify invalid-sid as SRv6 SID processing failure.