### PR TITLE
Add MTU fragmentation discard subclasses

### DIFF
--- a/draft-ietf-opsawg-discardmodel.md
+++ b/draft-ietf-opsawg-discardmodel.md
@@ -319,7 +319,10 @@ discards/errors/:
    : These are frames discarded due to errors in the received Layer 2 frame, including: Cyclic Redundancy Check (CRC) errors, invalid Media Access Control (MAC) addresses, invalid VLAN tags, frame size violations and other malformed frame conditions.
 
    * discards/errors/l3/rx/:
-   : These discards occur due to errors in the received packet, indicating an upstream problem rather than an issue with the device dropping the errored packets, including: header checksum errors,  MTU exceeded, invalid packet errors (i.e., incorrect version, incorrect header length, invalid options, and other malformed packet conditions).
+   : These discards occur due to errors in the received packet, indicating an upstream problem rather than an issue with the device dropping the errored packets, including: header checksum errors and invalid packet errors (i.e., incorrect version, incorrect header length, invalid options, and other malformed packet conditions).
+
+   * discards/errors/l3/mtu-exceeded/:
+   : These discards occur when the packet size exceeds the applicable MTU. The subclasses distinguish whether the forwarding node was permitted to fragment the packet ({{?RFC791}}, {{?RFC8200}}).
 
    * discards/errors/l3/ttl-expired:
    : These discards occur due to TTL (or Hop limit) expiry. These can occur, e.g., for the following reasons: normal trace-route operations, end-system TTL/Hop limit set too low, or routing loops in the network.

--- a/draft-ietf-opsawg-discardmodel.md
+++ b/draft-ietf-opsawg-discardmodel.md
@@ -322,7 +322,7 @@ discards/errors/:
    : These discards occur due to errors in the received packet, indicating an upstream problem rather than an issue with the device dropping the errored packets, including: header checksum errors and invalid packet errors (i.e., incorrect version, incorrect header length, invalid options, and other malformed packet conditions).
 
    * discards/errors/l3/mtu-exceeded/:
-   : These discards occur when the packet size exceeds the applicable MTU. The subclasses distinguish whether the forwarding node was permitted to fragment the packet ({{?RFC791}}, {{?RFC8200}}).
+   : These discards occur when the packet size exceeds the applicable MTU. The subclasses distinguish whether the forwarding node was permitted to fragment the packet ({{Sections 3.1 and 3.2 of !RFC791}}, {{Sections 4.5 and 5 of !RFC8200}}).
 
    * discards/errors/l3/ttl-expired:
    : These discards occur due to TTL (or Hop limit) expiry. These can occur, e.g., for the following reasons: normal trace-route operations, end-system TTL/Hop limit set too low, or routing loops in the network.

--- a/yang/ietf-packet-discard-reporting-common.yang
+++ b/yang/ietf-packet-discard-reporting-common.yang
@@ -326,12 +326,6 @@ module ietf-packet-discard-reporting-common {
           "The number of received packets discarded due
            to a checksum error.";
       }
-      leaf mtu-exceeded {
-        type yang:counter64;
-        description
-          "The number of received packets discarded due to
-           MTU exceeded.";
-      }
       leaf invalid-packet {
         type yang:counter64;
         description
@@ -341,6 +335,41 @@ module ietf-packet-discard-reporting-common {
            version, invalid flags or control bits, malformed
            packets.";
       }
+    }
+    container mtu-exceeded {
+      description
+        "Counters for packets discarded because their size exceeded
+         the applicable Maximum Transmission Unit (MTU).";
+      leaf packets {
+        type yang:counter64;
+        description
+          "The total number of packets discarded because their size
+           exceeded the applicable MTU.  This includes packets
+           reported by the more specific counters in this
+           container.";
+      }
+      leaf fragmentation-not-permitted {
+        type yang:counter64;
+        description
+          "The number of packets discarded because the packet size
+           exceeded the applicable MTU and the forwarding node was
+           not permitted to fragment the packet.  This includes IPv4
+           packets with the Don't Fragment (DF) bit set and IPv6
+           packets, which forwarding nodes do not fragment.";
+      }
+      leaf fragmentation-permitted-not-performed {
+        type yang:counter64;
+        description
+          "The number of packets discarded because the packet size
+           exceeded the applicable MTU, fragmentation was permitted
+           in principle, but the packet was not fragmented and
+           forwarded.  This includes IPv4 packets with the DF bit
+           clear.";
+      }
+      reference
+        "RFC 791: Internet Protocol, Sections 3.1 and 3.2
+         RFC 8200: Internet Protocol, Version 6 (IPv6)
+                   Specification, Sections 4.5 and 5";
     }
     leaf ttl-expired {
       type yang:counter64;

--- a/yang/trees/ietf-packet-discard-reporting-sx.tree
+++ b/yang/trees/ietf-packet-discard-reporting-sx.tree
@@ -71,8 +71,14 @@ module: ietf-packet-discard-reporting-sx
     |     |  |  +-- rx
     |     |  |  |  +-- packets?          yang:counter64
     |     |  |  |  +-- checksum-error?   yang:counter64
-    |     |  |  |  +-- mtu-exceeded?     yang:counter64
     |     |  |  |  +-- invalid-packet?   yang:counter64
+    |     |  |  +-- mtu-exceeded
+    |     |  |  |  +-- packets?
+    |     |  |  |  |       yang:counter64
+    |     |  |  |  +-- fragmentation-not-permitted?
+    |     |  |  |  |       yang:counter64
+    |     |  |  |  +-- fragmentation-permitted-not-performed?
+    |     |  |  |          yang:counter64
     |     |  |  +-- ttl-expired?     yang:counter64
     |     |  |  +-- no-route?        yang:counter64
     |     |  |  +-- invalid-sid?     yang:counter64
@@ -163,8 +169,14 @@ module: ietf-packet-discard-reporting-sx
     |     |  |  +-- rx
     |     |  |  |  +-- packets?          yang:counter64
     |     |  |  |  +-- checksum-error?   yang:counter64
-    |     |  |  |  +-- mtu-exceeded?     yang:counter64
     |     |  |  |  +-- invalid-packet?   yang:counter64
+    |     |  |  +-- mtu-exceeded
+    |     |  |  |  +-- packets?
+    |     |  |  |  |       yang:counter64
+    |     |  |  |  +-- fragmentation-not-permitted?
+    |     |  |  |  |       yang:counter64
+    |     |  |  |  +-- fragmentation-permitted-not-performed?
+    |     |  |  |          yang:counter64
     |     |  |  +-- ttl-expired?     yang:counter64
     |     |  |  +-- no-route?        yang:counter64
     |     |  |  +-- invalid-sid?     yang:counter64
@@ -254,8 +266,14 @@ module: ietf-packet-discard-reporting-sx
           |  |  +-- rx
           |  |  |  +-- packets?          yang:counter64
           |  |  |  +-- checksum-error?   yang:counter64
-          |  |  |  +-- mtu-exceeded?     yang:counter64
           |  |  |  +-- invalid-packet?   yang:counter64
+          |  |  +-- mtu-exceeded
+          |  |  |  +-- packets?
+          |  |  |  |       yang:counter64
+          |  |  |  +-- fragmentation-not-permitted?
+          |  |  |  |       yang:counter64
+          |  |  |  +-- fragmentation-permitted-not-performed?
+          |  |  |          yang:counter64
           |  |  +-- ttl-expired?     yang:counter64
           |  |  +-- no-route?        yang:counter64
           |  |  +-- invalid-sid?     yang:counter64

--- a/yang/trees/ietf-packet-discard-reporting.tree
+++ b/yang/trees/ietf-packet-discard-reporting.tree
@@ -74,8 +74,14 @@ module: ietf-packet-discard-reporting
           |  |  +--ro rx
           |  |  |  +--ro packets?          yang:counter64
           |  |  |  +--ro checksum-error?   yang:counter64
-          |  |  |  +--ro mtu-exceeded?     yang:counter64
           |  |  |  +--ro invalid-packet?   yang:counter64
+          |  |  +--ro mtu-exceeded
+          |  |  |  +--ro packets?
+          |  |  |  |       yang:counter64
+          |  |  |  +--ro fragmentation-not-permitted?
+          |  |  |  |       yang:counter64
+          |  |  |  +--ro fragmentation-permitted-not-performed?
+          |  |  |          yang:counter64
           |  |  +--ro ttl-expired?     yang:counter64
           |  |  +--ro no-route?        yang:counter64
           |  |  +--ro invalid-sid?     yang:counter64
@@ -167,8 +173,14 @@ module: ietf-packet-discard-reporting
           |  |  +--ro rx
           |  |  |  +--ro packets?          yang:counter64
           |  |  |  +--ro checksum-error?   yang:counter64
-          |  |  |  +--ro mtu-exceeded?     yang:counter64
           |  |  |  +--ro invalid-packet?   yang:counter64
+          |  |  +--ro mtu-exceeded
+          |  |  |  +--ro packets?
+          |  |  |  |       yang:counter64
+          |  |  |  +--ro fragmentation-not-permitted?
+          |  |  |  |       yang:counter64
+          |  |  |  +--ro fragmentation-permitted-not-performed?
+          |  |  |          yang:counter64
           |  |  +--ro ttl-expired?     yang:counter64
           |  |  +--ro no-route?        yang:counter64
           |  |  +--ro invalid-sid?     yang:counter64


### PR DESCRIPTION
Refs #81

Add an aggregate `packets` counter:
- `fragmentation-not-permitted` for IPv4 packets with DF set and IPv6 packets; and
- `fragmentation-permitted-not-performed` for fragmentable IPv4 packets that were discarded without being fragmented.
